### PR TITLE
Add required default transform and test usage example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,13 +12,30 @@ To enable the processor please add the following rule to the `transform` object 
 "jest": {
     // ...
     transform: {
+        "\\.js$": "babel-jest"
         "\\.hbs$": "jest-handlebars",
     }
     // ...
 }
 ```
 
-Now all imported handlebars files will get compiled by the processor and the render function is imported.
+Now all imported handlebars files will get compiled by the processor and the render function is imported. You will need to add `babel-jest` for `.js` files if you previously had no transforms added as the default.
+
+## Tests
+
+```hbs
+<!-- greetings.hbs -->
+<h1>Hello {{name}}</h1>
+```
+
+```js
+import greetingsHbs from './greetings.hbs';
+
+test('Says hello to name', () => {
+    const html = greetingsHbs({name: 'User'});
+    expect(html).toEqual('<h1>Hello User</h1>');
+});
+```
 
 ## Author
 Johannes Pichler


### PR DESCRIPTION
## Changes

- Adds `.js` transform to Jest config - useful if you previously didn't have anything, as this is the default that you'll need.
- Also adds an example of how to utilize the import in a test.