### PR TITLE
Compatibility for Jest 28

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,10 @@
 module.exports = {
     process(src, filename) {
-        return `
-            const Handlebars = require('handlebars');
-            module.exports = Handlebars.compile(\`${src}\`);
-        `;
+        return {
+            code: `
+                const Handlebars = require('handlebars');
+                module.exports = Handlebars.compile(\`${src}\`);
+            `
+        };
     },
 };


### PR DESCRIPTION
`jest-handlebars` module fails in Jest 28 with this error:

```
Invalid return value:
`process()` or/and `processAsync()` method of code transformer found at 
"/Users/myapp/node_modules/jest-handlebars/index.js" 
should return an object or a Promise resolving to an object. The object 
must have `code` property with a string of processed code.
This error may be caused by a breaking change in Jest 28:
https://jestjs.io/docs/upgrading-to-jest28#transformer
Code Transformation Documentation:
https://jestjs.io/docs/code-transformation
```

This is due to the change here: https://jestjs.io/docs/upgrading-to-jest28#transformer

Unfortunately this PR will make `jest-handlebars` no longer compatible with Jest <=27, so it would need to be published a new major version change.

You can test this PR by installing it your project via this npm dependency definition:

```json
"devDependencies": {
    "jest-handlebars": "fetzi/jest-handlebars#pull/3/head"
}
```